### PR TITLE
Fix health check endpoint: clarify configured vs healthy status

### DIFF
--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -10,6 +10,7 @@ import structlog
 from models.responses import HealthCheckResponse
 from models.internal import ServiceStatus
 from core.dependencies import get_service_status
+from config.settings import settings
 
 log = structlog.get_logger()
 
@@ -60,21 +61,25 @@ async def detailed_service_status(
     
     return {
         "openai": {
-            "configured": service_status.openai,
+            "configured": settings.has_openai_config,
+            "healthy": service_status.openai,
             "status": "healthy" if service_status.openai else "unavailable"
         },
         "aws": {
             "s3": {
-                "configured": service_status.aws_s3,
+                "configured": settings.has_aws_config,
+                "healthy": service_status.aws_s3,
                 "status": "healthy" if service_status.aws_s3 else "unavailable"
             },
             "athena": {
-                "configured": service_status.aws_athena,
+                "configured": settings.has_aws_config,
+                "healthy": service_status.aws_athena,
                 "status": "healthy" if service_status.aws_athena else "unavailable"
             }
         },
         "firebase": {
-            "configured": service_status.firebase,
+            "configured": settings.has_firebase_config,
+            "healthy": service_status.firebase,
             "status": "healthy" if service_status.firebase else "unavailable"
         },
         "overall": {


### PR DESCRIPTION
## Problem

The health check endpoint at `/api/services/status` had misleading `"configured"` keys that actually reflected live health checks rather than configuration presence. This made it difficult to distinguish between:
- Missing configuration (no API keys)
- Configuration present but service unhealthy (network issues, invalid credentials, etc.)

## Solution

Implemented **Option B** approach:
- **`"configured"`**: Now shows actual configuration presence using `settings.has_*_config` properties
- **`"healthy"`**: New field showing runtime health check results (what the old "configured" field actually was)
- **`"status"`**: Kept existing human-readable status field

## Changes

### Before
```json
"openai": {
    "configured": service_status.openai,  // Misleading - this was runtime health
    "status": "healthy"
}
```

### After  
```json
"openai": {
    "configured": settings.has_openai_config,  // True config presence
    "healthy": service_status.openai,          // Runtime health status
    "status": "healthy"
}
```

## Benefits

- **Clear debugging**: Immediately know if issue is missing config vs service connectivity
- **Better monitoring**: Can distinguish between different types of failures
- **Accurate naming**: Field names now match what they actually represent

## Example Scenarios

| Scenario | configured | healthy | Meaning |
|----------|------------|---------|----------|
| ✅ Working | `true` | `true` | Service fully operational |
| ⚠️ Config but unhealthy | `true` | `false` | API key exists but service down/invalid |
| ❌ Not configured | `false` | `false` | Need to add API key/credentials |

## Files Changed

- `backend/routes/health.py`: Updated detailed status endpoint
  - Added import for `config.settings`
  - Updated return object with both `configured` and `healthy` fields

## Testing

- [x] Code compiles without errors
- [x] Maintains backward compatibility (existing `status` field unchanged)
- [x] Uses existing configuration check methods from `settings`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author